### PR TITLE
EWB-4104: Update super pom to 0.34.1

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MavenProjectsManager">
     <option name="originalFiles">
       <list>
@@ -7,5 +8,5 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="corretto-11" project-jdk-type="JavaSDK" />
 </project>

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ## [1.3.0] - UNRELEASED
 
 ### Breaking Changes
-* None.
+* Use super pom version 0.34.x, which uses Vert.x version 4.4.6 (major version change 3 &rarr; 4).
 
 ### New Features
 * None.

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.zepben.maven</groupId>
         <artifactId>evolve-super-pom</artifactId>
-        <version>0.23.0</version>
+        <version>0.34.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.zepben.maven</groupId>
         <artifactId>evolve-super-pom</artifactId>
-        <version>0.34.0</version>
+        <version>0.34.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/src/main/java/com/zepben/vertxutils/json/JsonUtils.java
+++ b/src/main/java/com/zepben/vertxutils/json/JsonUtils.java
@@ -120,7 +120,7 @@ public class JsonUtils {
      * @throws ParsingException if the value is not a string
      */
     public static Optional<String> extractOptionalString(JsonObject json, String key) throws ParsingException {
-        return extractOptional(json, key, JsonObject::getString, "string");
+        return extractOptional(json, key, JsonValueExtractors::getStringStrict, "string");
     }
 
     /**
@@ -132,7 +132,7 @@ public class JsonUtils {
      * @throws ParsingException if the value is not a string, or is not found
      */
     public static String extractRequiredString(JsonObject json, String key) throws ParsingException {
-        return extractRequired(json, key, JsonObject::getString, "string");
+        return extractRequired(json, key, JsonValueExtractors::getStringStrict, "string");
     }
 
     /**
@@ -240,7 +240,7 @@ public class JsonUtils {
      * @throws ParsingException if the value is not a list of strings.
      */
     public static Optional<List<String>> extractOptionalStringList(JsonObject json, String key) throws ParsingException {
-        return extractOptionalList(json, key, JsonArray::getString, "strings");
+        return extractOptionalList(json, key, JsonValueExtractors::getStringStrict, "strings");
     }
 
     /**
@@ -252,7 +252,7 @@ public class JsonUtils {
      * @throws ParsingException if the value is not a list of strings, or is not found.
      */
     public static List<String> extractRequiredStringList(JsonObject json, String key) throws ParsingException {
-        return extractRequiredList(json, key, JsonArray::getString, "strings");
+        return extractRequiredList(json, key, JsonValueExtractors::getStringStrict, "strings");
     }
 
     /**

--- a/src/test/java/com/zepben/vertxutils/routing/ChunkedResponse/HttpChunkedJsonResponseTest.java
+++ b/src/test/java/com/zepben/vertxutils/routing/ChunkedResponse/HttpChunkedJsonResponseTest.java
@@ -9,27 +9,34 @@
 package com.zepben.vertxutils.routing.ChunkedResponse;
 
 import io.vertx.core.http.HttpServerResponse;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class HttpChunkedJsonResponseTest {
 
     @Mock
     private HttpServerResponse httpServerResponse;
+    private AutoCloseable closeable;
 
     @BeforeEach
     public void setUp() {
-        initMocks(this);
+        closeable = openMocks(this);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        closeable.close();
     }
 
     @Test
     public void doEnd() {
-        doNothing().when(httpServerResponse).end(any(String.class));
+        doReturn(null).when(httpServerResponse).end(any(String.class));
 
         // Check that ending the response sends the remaining buffer.
         new HttpChunkedJsonResponse(httpServerResponse).ofArray().endArray();
@@ -38,7 +45,7 @@ public class HttpChunkedJsonResponseTest {
 
     @Test
     public void doSend() {
-        doReturn(httpServerResponse).when(httpServerResponse).write(any(String.class));
+        doReturn(null).when(httpServerResponse).write(any(String.class));
 
         ChunkedJsonResponse.JsonArray jsonArray = new HttpChunkedJsonResponse(httpServerResponse, 10).ofArray();
 
@@ -70,7 +77,7 @@ public class HttpChunkedJsonResponseTest {
         Mockito.verify(httpServerResponse).end("[]");
 
         doReturn(true).when(httpServerResponse).closed();
-        doReturn(httpServerResponse).when(httpServerResponse).write(any(String.class));
+        doReturn(null).when(httpServerResponse).write(any(String.class));
         ChunkedJsonResponse.JsonArray jsonArray = new HttpChunkedJsonResponse(httpServerResponse, 10).ofArray();
 
         jsonArray.addArrayItem("this").send(false);

--- a/src/test/java/com/zepben/vertxutils/routing/ChunkedResponse/HttpChunkedJsonResponseTest.java
+++ b/src/test/java/com/zepben/vertxutils/routing/ChunkedResponse/HttpChunkedJsonResponseTest.java
@@ -22,16 +22,16 @@ public class HttpChunkedJsonResponseTest {
 
     @Mock
     private HttpServerResponse httpServerResponse;
-    private AutoCloseable closeable;
+    private AutoCloseable mockitoSession;
 
     @BeforeEach
     public void setUp() {
-        closeable = openMocks(this);
+        mockitoSession = openMocks(this);
     }
 
     @AfterEach
     public void tearDown() throws Exception {
-        closeable.close();
+        mockitoSession.close();
     }
 
     @Test


### PR DESCRIPTION
# Description

Use super pom version 0.34.1. This comes with breaking changes for Vert.x, namely for `JsonObject::getString` and `JsonArray::getString`. These functions now automatically convert certain non-strings into strings e.g. numbers, so new helper functions are created to restore the strict versions.

# Associated tasks

Tasks blocking this one:
- [x] https://github.com/zepben/evolve-super-pom/pull/36

Tasks this is blocking:
- https://github.com/zepben/evolve-conn-jvm/pull/12
- https://github.com/zepben/ewb-network-routes/pull/127
- https://github.com/zepben/energy-workbench-server/pull/129

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [x] I have updated the changelog.
- [ ] ~I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

Updates Vert.x major version (3 -> 4).