### PR TITLE
EWB-4224: Added Vert.x test helpers that used to be part of the `test-utils` library.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@
 * Use super pom version 0.34.x, which uses Vert.x version 4.4.6 (major version change 3 &rarr; 4).
 
 ### New Features
-* None.
+* Added Vert.x test helpers that used to be part of the `test-utils` library. These have been updated to support
 
 ### Enhancements
 * None.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,8 @@
   ~ License, v. 2.0. If a copy of the MPL was not distributed with this
   ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>com.zepben.maven</groupId>
         <artifactId>evolve-super-pom</artifactId>
@@ -111,15 +112,29 @@
         <dependency>
             <groupId>com.zepben</groupId>
             <artifactId>test-utils</artifactId>
-            <version>1.0.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.rest-assured</groupId>
-            <artifactId>rest-assured</artifactId>
+            <version>2.0.0-SNAPSHOT1</version>
             <scope>test</scope>
         </dependency>
 
+        <!-- Provided dependencies are used for the testing classes we expose to prevent pulling these dependencies
+         into all project that use them outside the test scope -->
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>5.3.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/zepben/vertxutils/testing/DeployRestVerticleHelper.java
+++ b/src/main/java/com/zepben/vertxutils/testing/DeployRestVerticleHelper.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.vertxutils.testing;
+
+import com.zepben.annotations.EverythingIsNonnullByDefault;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.jayway.awaitility.Awaitility.await;
+
+@SuppressWarnings("WeakerAccess")
+@EverythingIsNonnullByDefault
+public class DeployRestVerticleHelper implements AutoCloseable {
+
+    private final RequestSpecification requestSpec;
+    private final Vertx vertx;
+
+    public DeployRestVerticleHelper(Class<?> verticleClass, JsonObject config) {
+        try {
+            int port = getRandomPortNumber();
+            config.put("http.port", port);
+
+            // Start the server
+            Promise<Void> promise = Promise.promise();
+            Future<Void> future = promise.future();
+            vertx = Vertx.vertx();
+            DeploymentOptions options = new DeploymentOptions().setConfig(config);
+            vertx.deployVerticle(verticleClass.getName(),
+                options,
+                ar -> {
+                    if (ar.succeeded())
+                        promise.complete();
+                    else
+                        promise.fail(ar.cause());
+                });
+
+            await().atMost(5, TimeUnit.SECONDS).until(future::isComplete);
+
+            if (!future.succeeded())
+                throw new AssertionError(future.cause().getMessage());
+
+            requestSpec = new RequestSpecBuilder().setBaseUri("http://localhost").setPort(port).build();
+        } catch (IOException ex) {
+            throw new AssertionError("Failed to start server", ex);
+        }
+    }
+
+    @Override
+    public void close() {
+        AtomicBoolean done = new AtomicBoolean(false);
+        vertx.close(v -> done.set(true));
+        await().until(done::get);
+    }
+
+    @SuppressWarnings("UnusedReturnValue")
+    public RequestSpecification requestSpec() {
+        return requestSpec;
+    }
+
+    public int getRandomPortNumber() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+
+}

--- a/src/main/java/com/zepben/vertxutils/testing/MockRoutingContext.java
+++ b/src/main/java/com/zepben/vertxutils/testing/MockRoutingContext.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.vertxutils.testing;
+
+import com.zepben.annotations.EverythingIsNonnullByDefault;
+import com.zepben.vertxutils.routing.RoutingContextEx;
+import com.zepben.vertxutils.routing.handlers.params.PathParamRule;
+import com.zepben.vertxutils.routing.handlers.params.PathParams;
+import com.zepben.vertxutils.routing.handlers.params.QueryParamRule;
+import com.zepben.vertxutils.routing.handlers.params.QueryParams;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+
+import javax.annotation.Nullable;
+import java.util.*;
+
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("WeakerAccess")
+@EverythingIsNonnullByDefault
+public class MockRoutingContext {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        @Nullable private PathParams pathParams;
+        private final Map<String, Object> pathParamsMap = new HashMap<>();
+        @Nullable private QueryParams queryParams;
+        private final Map<String, List<Object>> queryParamsMap = new HashMap<>();
+        private final Set<QueryParamRule<?>> queryParamRules = new HashSet<>();
+        @Nullable private Object decodedBody;
+
+        public RoutingContext build() {
+            RoutingContext context = mock(RoutingContext.class);
+            HttpServerRequest request = mock(HttpServerRequest.class, RETURNS_SELF);
+            HttpServerResponse response = mock(HttpServerResponse.class, RETURNS_SELF);
+
+            doReturn(request).when(context).request();
+            doReturn(response).when(context).response();
+
+            doReturn(Objects.requireNonNullElseGet(pathParams, () -> new PathParams(pathParamsMap))).when(context).get(RoutingContextEx.PATH_PARAMS_KEY);
+
+            doReturn(Objects.requireNonNullElseGet(queryParams, () -> new QueryParams(queryParamRules, queryParamsMap))).when(context).get(RoutingContextEx.QUERY_PARAMS_KEY);
+
+            doReturn(decodedBody).when(context).get(RoutingContextEx.BODY_KEY);
+
+            return context;
+        }
+
+        public Builder pathParams(PathParams params) {
+            pathParams = params;
+            return this;
+        }
+
+        public Builder pathParam(PathParamRule<?> rule, Object value) {
+            pathParamsMap.put(rule.name(), value);
+            return this;
+        }
+
+        public Builder queryParams(QueryParams params) {
+            queryParams = params;
+            return this;
+        }
+
+        public Builder queryParam(QueryParamRule<?> rule) {
+            queryParams(rule);
+            return this;
+        }
+
+        public Builder queryParams(QueryParamRule<?>... rule) {
+            queryParamRules.addAll(Arrays.asList(rule));
+            return this;
+        }
+
+        public Builder queryParam(QueryParamRule<?> rule, Object... values) {
+            queryParam(rule);
+            queryParamsMap.computeIfAbsent(rule.name(), k -> new ArrayList<>()).addAll(Arrays.asList(values));
+            return this;
+        }
+
+        public Builder decodedBody(Object decodedBody) {
+            this.decodedBody = decodedBody;
+            return this;
+        }
+
+        private Builder() {
+        }
+
+    }
+
+    private MockRoutingContext() {
+    }
+
+}

--- a/src/main/java/com/zepben/vertxutils/testing/TestHttpServer.java
+++ b/src/main/java/com/zepben/vertxutils/testing/TestHttpServer.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.vertxutils.testing;
+
+import com.zepben.vertxutils.routing.Route;
+import com.zepben.vertxutils.routing.RouteRegister;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import io.vertx.ext.web.Router;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.ServerSocket;
+import java.util.concurrent.CountDownLatch;
+
+@SuppressWarnings("WeakerAccess")
+public class TestHttpServer implements AutoCloseable {
+
+    private final Vertx vertx;
+    private final HttpServer server;
+    private final Router router;
+    private final RouteRegister routeRegister;
+
+    public TestHttpServer() {
+        this(true);
+    }
+
+    public TestHttpServer(boolean orderBlockingRules) {
+        vertx = Vertx.vertx();
+        server = vertx.createHttpServer();
+        router = Router.router(vertx);
+        routeRegister = new RouteRegister(router, orderBlockingRules);
+    }
+
+    public TestHttpServer addRoute(Route route) {
+        routeRegister.add(route);
+        return this;
+    }
+
+    public TestHttpServer addRoutes(Iterable<Route> routes) {
+        routeRegister.add(routes);
+        return this;
+    }
+
+    public int listen() {
+        CountDownLatch latch = new CountDownLatch(1);
+        server.requestHandler(router)
+            .listen(getRandomPortNumber(), res -> {
+                if (res.failed())
+                    throw new RuntimeException(res.cause());
+
+                latch.countDown();
+            });
+
+        try {
+            latch.await();
+        } catch (InterruptedException ignored) {
+        }
+
+        return server.actualPort();
+    }
+
+    @Override
+    public void close() {
+        CountDownLatch latch = new CountDownLatch(2);
+        server.close(none -> latch.countDown());
+        vertx.close(none -> latch.countDown());
+
+        try {
+            latch.await();
+        } catch (InterruptedException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private int getRandomPortNumber() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+    }
+
+}

--- a/src/test/java/com/zepben/vertxutils/testing/DeployRestVerticleHelperTest.java
+++ b/src/test/java/com/zepben/vertxutils/testing/DeployRestVerticleHelperTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.vertxutils.testing;
+
+import com.zepben.testutils.junit.SystemLogExtension;
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static com.zepben.testutils.exception.ExpectException.expect;
+
+public class DeployRestVerticleHelperTest {
+
+    @RegisterExtension
+    public final SystemLogExtension systemErr = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess();
+
+    @AfterEach
+    void afterEach() {
+        TestVerticle.setOnStop(() -> {});
+        TestVerticle.setOnStart(() -> {});
+    }
+
+    @Test
+    public void coverageOnlyTest() throws Exception {
+        // TODO: Make this an actual test.
+        DeployRestVerticleHelper helper = buildHelper();
+        helper.requestSpec();
+        helper.getRandomPortNumber();
+        helper.close();
+
+        TestVerticle.setOnStart((promise) -> promise.fail("test start fail"));
+        expect(this::buildHelper).toThrow(AssertionError.class);
+    }
+
+    private DeployRestVerticleHelper buildHelper() {
+        return new DeployRestVerticleHelper(TestVerticle.class, new JsonObject());
+    }
+
+}

--- a/src/test/java/com/zepben/vertxutils/testing/MockRoutingContextTest.java
+++ b/src/test/java/com/zepben/vertxutils/testing/MockRoutingContextTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.vertxutils.testing;
+
+import com.zepben.vertxutils.routing.RoutingContextEx;
+import com.zepben.vertxutils.routing.handlers.params.*;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+public class MockRoutingContextTest {
+
+    @Test
+    public void builderPathParamsObject() {
+        PathParams pathParams = mock(PathParams.class);
+
+        RoutingContext context = MockRoutingContext.builder()
+            .pathParams(pathParams)
+            .build();
+
+        assertThat(RoutingContextEx.getPathParams(context), is(pathParams));
+    }
+
+    @Test
+    public void builderPathParams() {
+        PathParamRule<String> param1 = PathParamRule.of("param1", ParamType.STRING);
+        PathParamRule<String> param2 = PathParamRule.of("param2", ParamType.STRING);
+        PathParamRule<Integer> param3 = PathParamRule.of("param3", ParamType.INT);
+
+        RoutingContext context = MockRoutingContext.builder()
+            .pathParam(param1, "value1")
+            .pathParam(param2, "value2")
+            .pathParam(param3, 3)
+            .build();
+
+        PathParams pathParams = RoutingContextEx.getPathParams(context);
+        assertThat(pathParams.get(param1), equalTo("value1"));
+        assertThat(pathParams.get(param2), equalTo("value2"));
+        assertThat(pathParams.get(param3), equalTo(3));
+    }
+
+    @Test
+    public void builderQueryParamsObject() {
+        QueryParams queryParams = mock(QueryParams.class);
+
+        RoutingContext context = MockRoutingContext.builder()
+            .queryParams(queryParams)
+            .build();
+
+        assertThat(RoutingContextEx.getQueryParams(context), is(queryParams));
+    }
+
+    @Test
+    public void builderQueryParams() {
+        QueryParamRule<String> param1 = QueryParamRule.of("param1", ParamType.STRING);
+        QueryParamRule<String> param2 = QueryParamRule.of("param2", ParamType.STRING, "default");
+        QueryParamRule<String> param3 = QueryParamRule.of("param3", ParamType.STRING);
+        QueryParamRule<String> param4 = QueryParamRule.of("param4", ParamType.STRING);
+        QueryParamRule<Integer> param5 = QueryParamRule.of("param5", ParamType.INT);
+
+        RoutingContext context = MockRoutingContext.builder()
+            .queryParam(param1, "value1")
+            .queryParam(param2)
+            .queryParams(param3, param4)
+            .queryParam(param5, 5)
+            .build();
+
+        QueryParams queryParams = RoutingContextEx.getQueryParams(context);
+        assertThat(queryParams.get(param1), equalTo("value1"));
+        assertThat(queryParams.get(param2), equalTo("default"));
+        assertThat(queryParams.exists(param3), equalTo(false));
+        assertThat(queryParams.exists(param4), equalTo(false));
+        assertThat(queryParams.get(param5), equalTo(5));
+    }
+
+    @Test
+    public void builderBody() {
+        Object body = new Object();
+
+        RoutingContext context = MockRoutingContext.builder()
+            .decodedBody(body)
+            .build();
+
+        Object decodedBody = RoutingContextEx.getDecodedBody(context);
+        assertThat(decodedBody, is(body));
+    }
+
+}

--- a/src/test/java/com/zepben/vertxutils/testing/TestHttpServerTest.java
+++ b/src/test/java/com/zepben/vertxutils/testing/TestHttpServerTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.vertxutils.testing;
+
+import com.zepben.vertxutils.routing.Route;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+public class TestHttpServerTest {
+
+    @Test
+    public void canServe() {
+        try (TestHttpServer server = new TestHttpServer()) {
+            Route route = Route.builder().path("/").addHandler(ctx -> ctx.response().end("The response!")).build();
+            int port = server.addRoute(route).listen();
+
+            given()
+                .port(port)
+                .get("/")
+                .then()
+                .statusCode(200)
+                .body(equalTo("The response!"));
+        }
+    }
+
+}

--- a/src/test/java/com/zepben/vertxutils/testing/TestVerticle.java
+++ b/src/test/java/com/zepben/vertxutils/testing/TestVerticle.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.vertxutils.testing;
+
+import com.zepben.annotations.EverythingIsNonnullByDefault;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+
+import java.util.function.Consumer;
+
+@SuppressWarnings("WeakerAccess")
+@EverythingIsNonnullByDefault
+public class TestVerticle extends AbstractVerticle {
+
+    public static void setOnStart(Runnable onStart) {
+        setOnStart((promise) -> {
+            onStart.run();
+            promise.complete();
+        });
+    }
+
+    public static void setOnStart(Consumer<Promise<Void>> onStart) {
+        TestVerticle.onStart = onStart;
+    }
+
+    public static void setOnStop(Runnable onStop) {
+        setOnStop((promise) -> {
+            onStop.run();
+            promise.complete();
+        });
+    }
+
+    public static void setOnStop(Consumer<Promise<Void>> onStop) {
+        TestVerticle.onStop = onStop;
+    }
+
+    private static Consumer<Promise<Void>> onStart = Promise::complete;
+    private static Consumer<Promise<Void>> onStop = Promise::complete;
+
+    @Override
+    public void start(Promise<Void> startPromise) {
+        onStart.accept(startPromise);
+    }
+
+    @Override
+    public void stop(Promise<Void> stopPromise) {
+        onStop.accept(stopPromise);
+    }
+
+}


### PR DESCRIPTION
# Description

Added Vert.x test helpers that used to be part of the `test-utils` library.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

None.
