### PR TITLE
[DEV-1867] Added the ability to register a collection of route groups.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,5 +8,5 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="corretto-11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="corretto-11" project-jdk-type="JavaSDK" />
 </project>

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@
 * None.
 
 ### Enhancements
-* None.
+* Added the ability to register a collection of route groups.
 
 ### Fixes
 * None.

--- a/src/main/java/com/zepben/vertxutils/routing/RouteRegister.java
+++ b/src/main/java/com/zepben/vertxutils/routing/RouteRegister.java
@@ -91,6 +91,13 @@ public class RouteRegister {
         return this;
     }
 
+    /**
+     * Register a collection of route groups with this RouteRegister. NOTE: This function can't be named `add` like the others due
+     * to type erasure making it have the same signature at the iterable for routes.
+     *
+     * @param routeGroups The collection of routes to register.
+     * @return This RouteRegister for fluent use.
+     */
     public RouteRegister addGroups(Iterable<RouteGroup> routeGroups) {
         routeGroups.forEach(this::add);
         return this;

--- a/src/main/java/com/zepben/vertxutils/routing/RouteRegister.java
+++ b/src/main/java/com/zepben/vertxutils/routing/RouteRegister.java
@@ -91,6 +91,11 @@ public class RouteRegister {
         return this;
     }
 
+    public RouteRegister addGroups(Iterable<RouteGroup> routeGroups) {
+        routeGroups.forEach(this::add);
+        return this;
+    }
+
     private String buildPath(String rootMount, String mountPath, @Nullable String routePath) {
         String path = rootMount;
         if (!mountPath.isEmpty())

--- a/src/test/java/com/zepben/vertxutils/routing/RouteRegisterTest.java
+++ b/src/test/java/com/zepben/vertxutils/routing/RouteRegisterTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.BiConsumer;
 
 import static org.mockito.Mockito.*;
@@ -158,6 +159,19 @@ public class RouteRegisterTest {
 
         verify(router).route("/group/route/1");
         verify(router).route("/group/route/2");
+    }
+
+    @Test
+    public void addRouteGroups() {
+        Route route1 = Route.builder().path("/route/1").build();
+        Route route2 = Route.builder().path("/route/2").build();
+        RouteGroup group1 = RouteGroup.create("/group1", List.of(route1));
+        RouteGroup group2 = RouteGroup.create("/group2", List.of(route2));
+
+        register.addGroups(List.of(group1, group2));
+
+        verify(router).route("/group1/route/1");
+        verify(router).route("/group2/route/2");
     }
 
     @Test


### PR DESCRIPTION
# Description

With the addition of v2 routes for some of the network routes, we now need the ability to register a collection of route groups. To prevent having messy looking code with looping over the collection and adding each item individually, we have added the ability to register the collection of route groups directly.

# Test Steps

Tested by unit tests, no real need to test it elsewhere.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

None breaking