### PR TITLE
[OPS-546] Bump version to be able to release properly

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,21 @@
 # Vertx Utils changelog
-## [1.8.0] - UNRELEASED
+## [1.9.0] - UNRELEASED
+### Breaking Changes
+* None.
+
+### New Features
+* None.
+
+### Enhancements
+* None.
+
+### Fixes
+* None.
+
+### Notes
+* None.
+
+## [1.8.0] - 2026-04-09
 ### Breaking Changes
 * This project requires JVM 17 to build
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.zepben</groupId>
     <artifactId>vertx-utils</artifactId>
-    <version>1.8.0b3</version>
+    <version>1.9.0b1</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Helpers and utils for working with Vert.x in Zepben projects.</description>


### PR DESCRIPTION
# Description

Our CI flows are currently broken for this repository due to a previously failed release, caused by a race condition between a `release` and a `snapshot` actions running at the same time. This version bump should fix the CI/Maven Central references to be able to release again via CI. 